### PR TITLE
Add GHA Matrix Build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,32 @@
+name: Matrix Build
+on:
+  push: 
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  schedule:
+    - cron: 0 9 * * *
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - os: windows-latest
+            crlf: fix
+    runs-on: ${{matrix.os}}
+    steps:
+      - if: ${{ matrix.crlf }}
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Zig
+        uses: goto-bus-stop/setup-zig@v1
+        with:
+          version: master
+
+      - run: zig build test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        comptime: [true, false]
         include:
           - os: windows-latest
             crlf: fix
@@ -30,4 +31,7 @@ jobs:
         with:
           version: master
 
-      - run: zig build test
+      - name: Run Tests
+        run: |
+          zig version
+          zig build test -Dcomptime-tests=${{ matrix.comptime }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         include:


### PR DESCRIPTION
This will build the project each morning, with each commit, and on each pull request using the latest Zig compiler on Linux, MacOS, and Windows.

Currently, both Windows builds will fail due to an allocation issue. This should be resolved once stage2/3 is used in Zig master. I've also seen Access Denied errors on Windows when running the renderFile API tests. Ubuntu-latest fails when comptime tests are enabled. I expect a memory issue since it runs locally, but I have not confirmed.

This will send you an e-mail each morning that it fails, so you may want to disable the e-mails or disable both the Windows and comptime parts of the Matrix build until there is a resolution for those.