### PR TITLE
Use stage1 until self-hosted fixes are applied

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Run Tests
         run: |
           zig version
-          zig build test ${{ matrix.coverage }} -Dcomptime-tests=${{ matrix.comptime }}
+          zig build test ${{ matrix.coverage }} -Dcomptime-tests=${{ matrix.comptime }} -fstage1
       
       - name: Upload Codecov
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.comptime == false }}

--- a/build.zig
+++ b/build.zig
@@ -25,7 +25,7 @@ pub fn build(b: *std.build.Builder) void {
         inline for (.{ .dynamic, .static }) |linkage| {
 
             // Appends the name "lib" on windows, in order to generate the same name "libmustache" for all platforms
-            const lib_name = (if (std.mem.startsWith(u8, platform[1], "win")) "lib" else "") ++ "mustache";
+            const lib_name = comptime (if (std.mem.startsWith(u8, platform[1], "win")) "lib" else "") ++ "mustache";
 
             const dynamic_lib = b.addStaticLibrary(lib_name, "src/exports.zig");
             dynamic_lib.linkage = linkage;


### PR DESCRIPTION
Switches the nightly build to use stage1 to avoid the daily failure.