### PR TITLE
Add support for zig package manager.

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -29,6 +29,9 @@ pub fn build(b: *std.build.Builder) void {
     dynamic_lib.linkLibC();
     b.installArtifact(dynamic_lib);
 
+    // Zig module
+    _ = b.addModule("mustache", .{ .source_file = .{ .path = "src/mustache.zig" } });
+
     // C FFI Sample
 
     {

--- a/build.zig
+++ b/build.zig
@@ -12,7 +12,7 @@ pub fn build(b: *std.build.Builder) void {
 
     // TODO re-add cross-compile
     const static_lib = b.addStaticLibrary(.{
-        .name = "mustache",
+        .name = "mustache-static",
         .root_source_file = .{ .path = "src/exports.zig" },
         .target = target,
         .optimize = mode,

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,4 @@
+.{
+    .name = "mustache",
+    .version = "0.0.1",
+}


### PR DESCRIPTION
so the library can be used without git submodule or vendoring the source. 

There's not much documentation on the new zig package management yet but this seems to be the way to do it.