### PR TITLE
Zig 0.14-master update fixes

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -81,7 +81,8 @@ pub fn build(b: *std.Build) void {
     // Tests
 
     var comptime_tests = b.addOptions();
-    const comptime_tests_enabled = b.option(bool, "comptime-tests", "Run comptime tests") orelse true;
+    // TODO: Re-enable comptime tests
+    const comptime_tests_enabled = b.option(bool, "comptime-tests", "Run comptime tests") orelse false;
     comptime_tests.addOption(bool, "comptime_tests_enabled", comptime_tests_enabled);
 
     {

--- a/src/parsing/parser.zig
+++ b/src/parsing/parser.zig
@@ -40,7 +40,7 @@ pub fn ParserType(comptime options: TemplateOptions) type {
 
         fn RenderError(comptime TRender: type) type {
             switch (@typeInfo(TRender)) {
-                .Pointer => |pointer| {
+                .pointer => |pointer| {
                     if (pointer.size == .One) {
                         const Render = pointer.child;
                         return Render.Error;

--- a/src/parsing/text_scanner.zig
+++ b/src/parsing/text_scanner.zig
@@ -256,12 +256,16 @@ pub fn TextScannerType(comptime Node: type, comptime options: TemplateOptions) t
                         self.moveLineCounter(char);
                     },
                     .matching_close => |*close_state| {
+                        // TODO: Remove this copy
+                        const close_state_copy: @TypeOf(self.state).MatchingCloseState = .{ .delimiter_index = close_state.delimiter_index, .part_type = close_state.part_type };
                         const delimiter_char = self.delimiters.ending_delimiter[close_state.delimiter_index];
                         if (char == delimiter_char) {
                             const next_index = close_state.delimiter_index + 1;
 
                             if (self.delimiters.ending_delimiter.len == next_index) {
-                                self.state = .{ .produce_close = close_state.part_type };
+                                // TODO: Determine why Zig states this line is "access of inactive union field"
+                                //self.state = .{ .produce_close = close_state.part_type };
+                                self.state = .{ .produce_close = close_state_copy.part_type };
                             } else {
                                 close_state.delimiter_index = next_index;
                             }

--- a/src/parsing/trimmer.zig
+++ b/src/parsing/trimmer.zig
@@ -16,7 +16,7 @@ const TemplateOptions = mustache.options.TemplateOptions;
 const parsing = @import("parsing.zig");
 
 pub fn TrimmerType(comptime TextScanner: type, comptime TrimmingIndex: type) type {
-    return if (@typeInfo(TrimmingIndex) == .Union)
+    return if (@typeInfo(TrimmingIndex) == .@"union")
         struct {
             const Trimmer = @This();
 

--- a/src/rendering/contexts/ffi/context.zig
+++ b/src/rendering/contexts/ffi/context.zig
@@ -83,7 +83,7 @@ pub fn ContextType(
                     if (path.len == 1) {
                         return self.callGet(&root_path, index);
                     } else {
-                        @setCold(true);
+                        @branchHint(.cold);
                         return self.getFromPath(&root_path, &root_path, path[1..], index);
                     }
                 } else {
@@ -161,7 +161,7 @@ pub fn ContextType(
                     if (path.len == 1) {
                         return self.callCapacityHint(&root_path);
                     } else {
-                        @setCold(true);
+                        @branchHint(.cold);
                         return self.capacityHintFromPath(&root_path, &root_path, path[1..]);
                     }
                 } else {
@@ -244,7 +244,7 @@ pub fn ContextType(
                             escape,
                         );
                     } else {
-                        @setCold(true);
+                        @branchHint(.cold);
                         return try self.interpolateFromPath(
                             data_render,
                             &root_path,

--- a/src/rendering/partials_map.zig
+++ b/src/rendering/partials_map.zig
@@ -47,9 +47,9 @@ pub fn PartialsMapType(comptime TPartials: type, comptime comptime_options: Rend
 
         pub fn isEmpty() bool {
             return switch (@typeInfo(TPartials)) {
-                .Void => true,
-                .Struct => |info| info.is_tuple and info.fields.len == 0,
-                inline .Array, .Vector => |info| return info.len == 0,
+                .void => true,
+                .@"struct" => |info| info.is_tuple and info.fields.len == 0,
+                inline .array, .vector => |info| return info.len == 0,
                 else => false,
             };
         }
@@ -136,7 +136,7 @@ pub fn PartialsMapType(comptime TPartials: type, comptime comptime_options: Rend
         fn isValidIndexable() bool {
             comptime {
                 if (stdx.isIndexable(TPartials) and !stdx.isTuple(TPartials)) {
-                    if (stdx.isSingleItemPtr(TPartials) and @typeInfo(meta.Child(TPartials)) == .Array) {
+                    if (stdx.isSingleItemPtr(TPartials) and @typeInfo(meta.Child(TPartials)) == .array) {
                         const Array = meta.Child(TPartials);
                         return isPartialsTupleElement(meta.Child(Array));
                     } else {
@@ -166,9 +166,9 @@ pub fn PartialsMapType(comptime TPartials: type, comptime comptime_options: Rend
 
         fn isValidMap() bool {
             comptime {
-                if (@typeInfo(TPartials) == .Struct and stdx.hasDecls(TPartials, .{ "KV", "get" })) {
+                if (@typeInfo(TPartials) == .@"struct" and stdx.hasDecls(TPartials, .{ "KV", "get" })) {
                     const KV = @field(TPartials, "KV");
-                    if (@typeInfo(KV) == .Struct and stdx.hasFields(KV, .{ "key", "value" })) {
+                    if (@typeInfo(KV) == .@"struct" and stdx.hasFields(KV, .{ "key", "value" })) {
                         const kv: KV = undefined;
                         return stdx.isZigString(@TypeOf(kv.key)) and
                             (@TypeOf(kv.value) == PartialsMap.Template or

--- a/src/stdx.zig
+++ b/src/stdx.zig
@@ -2,46 +2,46 @@ const std = @import("std");
 
 pub fn isSingleItemPtr(comptime T: type) bool {
     return switch (@typeInfo(T)) {
-        .Pointer => |info| return info.size == .One,
+        .pointer => |info| return info.size == .One,
         else => false,
     };
 }
 
 pub fn isTuple(comptime T: type) bool {
     return switch (@typeInfo(T)) {
-        .Struct => |info| return info.is_tuple,
+        .@"struct" => |info| return info.is_tuple,
         else => false,
     };
 }
 
 pub fn isIndexable(comptime T: type) bool {
     return switch (@typeInfo(T)) {
-        .Pointer => |info| if (info.size == .One)
+        .pointer => |info| if (info.size == .One)
             isIndexable(std.meta.Child(T))
         else
             true,
-        .Array, .Vector => true,
+        .array, .vector => true,
         else => isTuple(T),
     };
 }
 
 pub fn isSlice(comptime T: type) bool {
     return switch (@typeInfo(T)) {
-        .Pointer => |info| return info.size == .Slice,
+        .pointer => |info| return info.size == .Slice,
         else => false,
     };
 }
 
 pub fn isIntegral(comptime T: type) bool {
     return switch (@typeInfo(T)) {
-        .Int, .ComptimeInt => true,
+        .int, .comptime_int => true,
         else => false,
     };
 }
 
 pub fn isFloat(comptime T: type) bool {
     return switch (@typeInfo(T)) {
-        .Float, .ComptimeFloat => true,
+        .float, .comptime_float => true,
         else => false,
     };
 }
@@ -50,9 +50,9 @@ pub fn isZigString(comptime T: type) bool {
     return comptime blk: {
         // Only pointer types can be strings, no optionals
         const info = @typeInfo(T);
-        if (info != .Pointer) break :blk false;
+        if (info != .pointer) break :blk false;
 
-        const ptr = &info.Pointer;
+        const ptr = &info.pointer;
         // Check for CV qualifiers that would prevent coerction to []const u8
         if (ptr.is_volatile or ptr.is_allowzero) break :blk false;
 
@@ -64,8 +64,8 @@ pub fn isZigString(comptime T: type) bool {
         // Otherwise check if it's an array type that coerces to slice.
         if (ptr.size == .One) {
             const child = @typeInfo(ptr.child);
-            if (child == .Array) {
-                const arr = &child.Array;
+            if (child == .array) {
+                const arr = &child.array;
                 break :blk arr.child == u8;
             }
         }
@@ -93,7 +93,7 @@ pub fn hasFields(comptime T: type, comptime names: anytype) bool {
 pub inline fn canDeref(comptime TValue: type) bool {
     return isSingleItemPtr(TValue) and
         switch (@typeInfo(std.meta.Child(TValue))) {
-        .Fn, .Opaque => false,
+        .@"fn", .@"opaque" => false,
         else => true,
     };
 }

--- a/src/template.zig
+++ b/src/template.zig
@@ -448,14 +448,14 @@ pub fn TemplateLoaderType(comptime options: TemplateOptions) type {
             const renderInfo = @typeInfo(TRender);
 
             const ParserError = switch (parserInfo) {
-                .Struct => TParser.LoadError,
-                .Pointer => |info| if (info.size == .One) info.child.LoadError else @compileError("expected a reference to a parser, found " ++ @typeName(TParser)),
+                .@"struct" => TParser.LoadError,
+                .pointer => |info| if (info.size == .One) info.child.LoadError else @compileError("expected a reference to a parser, found " ++ @typeName(TParser)),
                 else => @compileError("expected a parser, found " ++ @typeName(TParser)),
             };
 
             const RenderError = switch (renderInfo) {
-                .Struct => TRender.Error,
-                .Pointer => |info| if (info.size == .One) info.child.Error else @compileError("expected a reference to a render, found " ++ @typeName(TParser)),
+                .@"struct" => TRender.Error,
+                .pointer => |info| if (info.size == .One) info.child.Error else @compileError("expected a reference to a render, found " ++ @typeName(TParser)),
                 else => @compileError("expected a render, found " ++ @typeName(TParser)),
             };
 


### PR DESCRIPTION
I've applied the fixes that I currently could toward allowing the majority of the tests to run once more (see #26). Namely,

- Update the use of the `@setCold(true)` builtin to `@branchHint(.cold)`
- Update `Type` fields to use the new naming:
  - `.Pointer` $\rightarrow$ `.pointer`
  - `.Null` $\rightarrow$ `.null`
  - `.Enum` $\rightarrow$ `.@"enum"`
  - and more

I was unable to get some of the comptime tests to continue to work and have disabled comptime tests in the meantime. If you have any ideas of why the `expectComptimeRender` and `expectComptimeRenderPartials` from `src/rendering/rendering.zig` functions would throw `error: runtime value contains reference to comptime var` when using `zig build test`, please let me know.

I also had to edit `src/rendering/contexts/native/lambda.zig` such that `isValidLambdaFunction` would no longer use the `std.builtin.Type.@"fn".Param` type due to receiving a error about there being invalid field access on a `@"union"`. Each of these areas which I had issues with should be marked with "TODO" comments.

Lastly, I understand that this is a large change and apologize for that in advance. If these changes are not something that you wish to do at this time that is fine with me and this PR can be closed. That being said, if there is anything else you need please let me know.