### PR TITLE
fix: use `Type.Fn.Param` once more

### DIFF
--- a/src/rendering/contexts/native/lambda.zig
+++ b/src/rendering/contexts/native/lambda.zig
@@ -138,12 +138,11 @@ pub fn isValidLambdaFunction(comptime TData: type, comptime TFn: type) bool {
         else => return false,
     };
 
-    // TODO: Update types to oncemore be strict on the input type
-    //const Type = std.builtin.Type;
-    //const FnParam = Type.@"fn".Param;
+    const Type = std.builtin.Type;
+    const FnParam = Type.Fn.Param;
 
     const paramIs = struct {
-        fn action(comptime param: anytype, comptime types: []const type) bool {
+        fn action(comptime param: FnParam, comptime types: []const type) bool {
             inline for (types) |compare_to| {
                 if (param.type) |param_type| {
                     if (param_type == compare_to) return true;


### PR DESCRIPTION
Commit e227da38 in PR #27 removed the type checking of the `param` field in the `action` function. Type checking has been added back using the proper Types supplied by Zig.

Ref: https://ziglang.org/documentation/master/std/#std.builtin.Type.Fn.Param

Thanks @batiati for the help!