### PR TITLE
fix: use lowercase enum for >= 0.14 compatibility

### DIFF
--- a/src/parsing/parser.zig
+++ b/src/parsing/parser.zig
@@ -41,7 +41,7 @@ pub fn ParserType(comptime options: TemplateOptions) type {
         fn RenderError(comptime TRender: type) type {
             switch (@typeInfo(TRender)) {
                 .pointer => |pointer| {
-                    if (pointer.size == .One) {
+                    if (pointer.size == .one) {
                         const Render = pointer.child;
                         return Render.Error;
                     }

--- a/src/rendering/Fields.zig
+++ b/src/rendering/Fields.zig
@@ -221,10 +221,10 @@ pub fn byValue(comptime TField: type) bool {
 pub inline fn isNull(comptime T: type, data: T) bool {
     return switch (@typeInfo(T)) {
         .pointer => |info| switch (info.size) {
-            .One => return isNull(@TypeOf(data.*), data.*),
-            .Slice => return false,
-            .Many => @compileError("[*] pointers not supported"),
-            .C => @compileError("[*c] pointers not supported"),
+            .one => return isNull(@TypeOf(data.*), data.*),
+            .slice => return false,
+            .many => @compileError("[*] pointers not supported"),
+            .c => @compileError("[*c] pointers not supported"),
         },
         .optional => return data == null,
         else => return false,
@@ -234,10 +234,10 @@ pub inline fn isNull(comptime T: type, data: T) bool {
 pub inline fn lenOf(comptime T: type, data: T) ?usize {
     return switch (@typeInfo(T)) {
         .pointer => |info| switch (info.size) {
-            .One => return null,
-            .Slice => return data.len,
-            .Many => @compileError("[*] pointers not supported"),
-            .C => @compileError("[*c] pointers not supported"),
+            .one => return null,
+            .slice => return data.len,
+            .many => @compileError("[*] pointers not supported"),
+            .c => @compileError("[*c] pointers not supported"),
         },
         .array, .vector => return data.len,
         .optional => if (data) |value| return lenOf(@TypeOf(value), value) else null,
@@ -385,7 +385,7 @@ test "enum literal " {
     // TODO: Not sure if it's a supported use case.
     if (true) return error.SkipZigTest;
 
-    const data = .{ .value = .AreYouSure, .level = .{ .value = .Totally } };
+    const data = .{ .value = .are_you_sure, .level = .{ .value = .totally } };
 
     const field = getField(&data, "value");
     try std.testing.expectEqual(field, data.value);
@@ -398,8 +398,8 @@ test "enum literal " {
 }
 
 test "enum" {
-    const Options = enum { AreYouSure, Totally };
-    var data = .{ .value = Options.AreYouSure, .level = .{ .value = Options.Totally } };
+    const Options = enum { are_you_sure, totally };
+    var data = .{ .value = Options.are_you_sure, .level = .{ .value = Options.totally } };
 
     const field = getField(&data, "value");
     try std.testing.expectEqual(field, data.value);

--- a/src/rendering/context.zig
+++ b/src/rendering/context.zig
@@ -53,8 +53,8 @@ pub fn PathResolutionType(comptime Payload: type) type {
 }
 
 pub const Escape = enum {
-    Escaped,
-    Unescaped,
+    escaped,
+    unescaped,
 };
 
 pub fn ContextType(

--- a/src/rendering/contexts/ffi/context.zig
+++ b/src/rendering/contexts/ffi/context.zig
@@ -689,12 +689,12 @@ const context_tests = struct {
 
         const writer = list.writer();
 
-        try interpolateCtx(writer, person_ctx, "id", .Unescaped);
+        try interpolateCtx(writer, person_ctx, "id", .unescaped);
         try testing.expectEqualStrings("100", list.items);
 
         list.clearAndFree();
 
-        try interpolateCtx(writer, person_ctx, "name", .Unescaped);
+        try interpolateCtx(writer, person_ctx, "name", .unescaped);
         try testing.expectEqualStrings("Angus McGyver", list.items);
 
         list.clearAndFree();
@@ -721,12 +721,12 @@ const context_tests = struct {
 
         const writer = list.writer();
 
-        try interpolateCtx(writer, person_ctx, "boss.id", .Unescaped);
+        try interpolateCtx(writer, person_ctx, "boss.id", .unescaped);
         try testing.expectEqualStrings("101", list.items);
 
         list.clearAndFree();
 
-        try interpolateCtx(writer, person_ctx, "boss.name", .Unescaped);
+        try interpolateCtx(writer, person_ctx, "boss.name", .unescaped);
         try testing.expectEqualStrings("Peter Thornton", list.items);
 
         list.clearAndFree();

--- a/src/rendering/contexts/native/context.zig
+++ b/src/rendering/contexts/native/context.zig
@@ -442,7 +442,7 @@ const context_tests = struct {
 
         const ctx = DummyRenderEngine.getContextType(if (by_value) data else @as(*const Data, &data));
 
-        try interpolateCtx(writer, ctx, path, .Unescaped);
+        try interpolateCtx(writer, ctx, path, .unescaped);
     }
 
     fn interpolateCtx(writer: anytype, ctx: DummyRenderEngine.Context, identifier: []const u8, escape: Escape) anyerror!void {
@@ -1030,7 +1030,7 @@ const context_tests = struct {
         {
             list.clearAndFree();
 
-            try interpolateCtx(writer, person_ctx, "address.street", .Unescaped);
+            try interpolateCtx(writer, person_ctx, "address.street", .unescaped);
             try testing.expectEqualStrings("nearby", list.items);
         }
 
@@ -1052,7 +1052,7 @@ const context_tests = struct {
         {
             list.clearAndFree();
 
-            try interpolateCtx(writer, address_ctx, "street", .Unescaped);
+            try interpolateCtx(writer, address_ctx, "street", .unescaped);
             try testing.expectEqualStrings("nearby", list.items);
         }
 
@@ -1074,14 +1074,14 @@ const context_tests = struct {
         {
             list.clearAndFree();
 
-            try interpolateCtx(writer, street_ctx, "", .Unescaped);
+            try interpolateCtx(writer, street_ctx, "", .unescaped);
             try testing.expectEqualStrings("nearby", list.items);
         }
 
         {
             list.clearAndFree();
 
-            try interpolateCtx(writer, street_ctx, ".", .Unescaped);
+            try interpolateCtx(writer, street_ctx, ".", .unescaped);
             try testing.expectEqualStrings("nearby", list.items);
         }
     }
@@ -1103,7 +1103,7 @@ const context_tests = struct {
         {
             list.clearAndFree();
 
-            try interpolateCtx(writer, person_ctx, "indication.address.street", .Unescaped);
+            try interpolateCtx(writer, person_ctx, "indication.address.street", .unescaped);
             try testing.expectEqualStrings("far away street", list.items);
         }
 
@@ -1125,7 +1125,7 @@ const context_tests = struct {
         {
             list.clearAndFree();
 
-            try interpolateCtx(writer, indication_ctx, "address.street", .Unescaped);
+            try interpolateCtx(writer, indication_ctx, "address.street", .unescaped);
             try testing.expectEqualStrings("far away street", list.items);
         }
 
@@ -1147,7 +1147,7 @@ const context_tests = struct {
         {
             list.clearAndFree();
 
-            try interpolateCtx(writer, address_ctx, "street", .Unescaped);
+            try interpolateCtx(writer, address_ctx, "street", .unescaped);
             try testing.expectEqualStrings("far away street", list.items);
         }
 
@@ -1169,14 +1169,14 @@ const context_tests = struct {
         {
             list.clearAndFree();
 
-            try interpolateCtx(writer, street_ctx, "", .Unescaped);
+            try interpolateCtx(writer, street_ctx, "", .unescaped);
             try testing.expectEqualStrings("far away street", list.items);
         }
 
         {
             list.clearAndFree();
 
-            try interpolateCtx(writer, street_ctx, ".", .Unescaped);
+            try interpolateCtx(writer, street_ctx, ".", .unescaped);
             try testing.expectEqualStrings("far away street", list.items);
         }
     }
@@ -1288,7 +1288,7 @@ const context_tests = struct {
 
         list.clearAndFree();
 
-        try interpolateCtx(writer, item_1, "name", .Unescaped);
+        try interpolateCtx(writer, item_1, "name", .unescaped);
         try testing.expectEqualStrings("item 1", list.items);
 
         const item_2 = iterator.next() orelse {
@@ -1298,7 +1298,7 @@ const context_tests = struct {
 
         list.clearAndFree();
 
-        try interpolateCtx(writer, item_2, "name", .Unescaped);
+        try interpolateCtx(writer, item_2, "name", .unescaped);
         try testing.expectEqualStrings("item 2", list.items);
 
         const no_more = iterator.next();

--- a/src/rendering/contexts/native/invoker.zig
+++ b/src/rendering/contexts/native/invoker.zig
@@ -108,7 +108,7 @@ pub fn InvokerType(
                             );
                         },
                         .pointer => |info| switch (info.size) {
-                            .One => return try recursiveFind(
+                            .one => return try recursiveFind(
                                 depth,
                                 info.child,
                                 action_param,
@@ -117,7 +117,7 @@ pub fn InvokerType(
                                 next_path_parts,
                                 index,
                             ),
-                            .Slice => {
+                            .slice => {
                                 //Slice supports the "len" field,
                                 if (next_path_parts.len == 0 and std.mem.eql(u8, "len", current_path_part)) {
                                     return if (next_path_parts.len == 0)
@@ -128,8 +128,8 @@ pub fn InvokerType(
                                         .chain_broken;
                                 }
                             },
-                            .Many => @compileError("[*] pointers not supported"),
-                            .C => @compileError("[*c] pointers not supported"),
+                            .many => @compileError("[*] pointers not supported"),
+                            .c => @compileError("[*c] pointers not supported"),
                         },
                         .optional => |info| {
                             if (!Fields.isNull(Data, data)) {
@@ -276,7 +276,7 @@ pub fn InvokerType(
                                 .iterator_consumed;
                         },
                         .pointer => |info| switch (info.size) {
-                            .One => {
+                            .one => {
                                 return try iterateAt(
                                     info.child,
                                     action_param,
@@ -284,7 +284,7 @@ pub fn InvokerType(
                                     index,
                                 );
                             },
-                            .Slice => {
+                            .slice => {
                                 //Slice of u8 is always string
                                 if (info.child != u8) {
                                     return if (index < data.len)

--- a/src/rendering/contexts/native/lambda.zig
+++ b/src/rendering/contexts/native/lambda.zig
@@ -274,7 +274,7 @@ pub fn LambdaInvokerType(comptime TData: type, comptime TFn: type) type {
                 switch (@typeInfo(TData)) {
                     .pointer => |info| {
                         switch (info.size) {
-                            .One => {
+                            .one => {
                                 if (info.child == fnArg) {
 
                                     // Context is a pointer, but the parameter is a value

--- a/src/stdx.zig
+++ b/src/stdx.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 
 pub fn isSingleItemPtr(comptime T: type) bool {
     return switch (@typeInfo(T)) {
-        .pointer => |info| return info.size == .One,
+        .pointer => |info| return info.size == .one,
         else => false,
     };
 }
@@ -16,7 +16,7 @@ pub fn isTuple(comptime T: type) bool {
 
 pub fn isIndexable(comptime T: type) bool {
     return switch (@typeInfo(T)) {
-        .pointer => |info| if (info.size == .One)
+        .pointer => |info| if (info.size == .one)
             isIndexable(std.meta.Child(T))
         else
             true,
@@ -27,7 +27,7 @@ pub fn isIndexable(comptime T: type) bool {
 
 pub fn isSlice(comptime T: type) bool {
     return switch (@typeInfo(T)) {
-        .pointer => |info| return info.size == .Slice,
+        .pointer => |info| return info.size == .slice,
         else => false,
     };
 }
@@ -57,12 +57,12 @@ pub fn isZigString(comptime T: type) bool {
         if (ptr.is_volatile or ptr.is_allowzero) break :blk false;
 
         // If it's already a slice, simple check.
-        if (ptr.size == .Slice) {
+        if (ptr.size == .slice) {
             break :blk ptr.child == u8;
         }
 
         // Otherwise check if it's an array type that coerces to slice.
-        if (ptr.size == .One) {
+        if (ptr.size == .one) {
             const child = @typeInfo(ptr.child);
             if (child == .array) {
                 const arr = &child.array;

--- a/src/template.zig
+++ b/src/template.zig
@@ -449,13 +449,13 @@ pub fn TemplateLoaderType(comptime options: TemplateOptions) type {
 
             const ParserError = switch (parserInfo) {
                 .@"struct" => TParser.LoadError,
-                .pointer => |info| if (info.size == .One) info.child.LoadError else @compileError("expected a reference to a parser, found " ++ @typeName(TParser)),
+                .pointer => |info| if (info.size == .one) info.child.LoadError else @compileError("expected a reference to a parser, found " ++ @typeName(TParser)),
                 else => @compileError("expected a parser, found " ++ @typeName(TParser)),
             };
 
             const RenderError = switch (renderInfo) {
                 .@"struct" => TRender.Error,
-                .pointer => |info| if (info.size == .One) info.child.Error else @compileError("expected a reference to a render, found " ++ @typeName(TParser)),
+                .pointer => |info| if (info.size == .one) info.child.Error else @compileError("expected a reference to a render, found " ++ @typeName(TParser)),
                 else => @compileError("expected a render, found " ++ @typeName(TParser)),
             };
 


### PR DESCRIPTION
Hey, I've had some issues with the latest versions of zig using this lib.
Since zig mostly uses underscore enums (also in the std now) I changed every enum to be underscore in this.
The tests are running successfully. 
You might want to not merge this PR until you're sure you don't want to have backwards compatibility with older versions.