### PR TITLE
fix popped optional node not being unwrapped

### DIFF
--- a/src/parsing/parser.zig
+++ b/src/parsing/parser.zig
@@ -244,7 +244,7 @@ pub fn ParserType(comptime options: TemplateOptions) type {
                                 self.canProducePartialNodes())
                             {
                                 // Remove the last node
-                                const last_node_value = nodes.pop();
+                                const last_node_value = nodes.pop().?;
 
                                 // Render all nodes produced until now
                                 try self.produceNodes(render);


### PR DESCRIPTION
Zig 0.14 sneaked in a breaking `.pop()` method change for containers, now they are unified and return `?T` like `.popOrNull()` used to do